### PR TITLE
fix: フロント側のDockerfile追加に伴いバックエンドのDockerfileを移動

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,7 +11,7 @@ COPY backend/Gemfile backend/Gemfile.lock ./
 RUN bundle config set --global frozen 1 \
  && bundle install
 
-# ソースコードコピー
+# backend 配下をまるごとコピー
 COPY backend/ ./
 
 # entrypoint.sh を実行可能にしておく

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -6,6 +6,8 @@ MyRouter = Proc.new do |env|
   path = req.path_info
   method = req.request_method
 
+  puts "DEBUG: method=#{method.inspect}, path_info=#{path.inspect}"
+
   case [method, path]
   when ['GET', '/']
     HomeController.new.index(req)

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ services:
   app:
     build: 
       context: .     # ビルドのコンテキストをプロジェクトルートにする
-      dockerfile: Dockerfile
+      dockerfile: backend/Dockerfile
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Chore: Docker ComposeファイルでバックエンドのDockerfileパスを`backend/Dockerfile`に変更し、ビルドコンテキスト内での位置を明示化しました。
- Documentation: Dockerfile内のコメントを更新し、「backend 配下をまるごとコピー」と説明を改善しました。
- Chore: `routes.rb`にデバッグ用のログ出力を追加し、HTTPメソッドとパス情報を記録するようにしました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->